### PR TITLE
Lines are now coloured based on call site depth.

### DIFF
--- a/src/Report.hs
+++ b/src/Report.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE RecordWildCards, TupleSections #-}
 
 module Report(
     reportText,
@@ -24,23 +24,50 @@ presort =
 reportHTML :: [Tree Val] -> [String]
 reportHTML vals =
     let vals2 = presort vals
-        indent i x = x{name = replicate (i*2) ' ' ++ name x}
         links = Set.fromList $ map (name . rootLabel) vals2
         anchor x = "<a id='" ++ show (hash x) ++ "'></a>"
-    in (["<pre>"] ++) $ (++ ["</pre>"]) $ intercalate [""] $
-        (" TOT   INH   IND" : map (showHTML links . rootLabel) (take 25 vals2)) :
+    in ((css ++ ["<pre>"]) ++) $ (++ ["</pre>"]) $ intercalate [""] $
+        (" TOT   INH   IND" : map (showHTML links . (0,) . rootLabel) (take 25 vals2)) :
         [ anchor (name $ rootLabel x) :
-          map (showHTML $ Set.delete (name $ rootLabel x) links) (flatten $ fmapTreeDepth indent x)
+          map (showHTML $ Set.delete (name $ rootLabel x) links) (flatten $ fmapTreeDepth (,) x)
         | x <- vals2]
 
-showHTML :: Set.Set String -> Val -> String
-showHTML xs Val{..} = intercalate "  "
-    [showDouble timeTot, showDouble timeInh, showDouble timeInd
-    ,spc ++ (if nam `Set.member` xs then link else nam) ++ " (" ++ show entries ++ ")"]
+showHTML :: Set.Set String -> (Int, Val) -> String
+showHTML xs (indent, Val{..}) =
+    (col $ intercalate "  " [showDouble timeTot, showDouble timeInh, showDouble timeInd]) ++
+    "  " ++
+    spc ++ (if name `Set.member` xs then link else colouredName) ++
+    col (" (" ++ show entries ++ ")")
     where
-        link = "<a href='#" ++ show (hash nam) ++ "'>" ++ nam ++ "</a>"
-        (spc,nam) = span isSpace name
+        link = "<a href='#" ++ show (hash name) ++ "'>" ++ colouredName ++ "</a>"
+        colouredName = col name
+        col = colourText indent
+        spc = replicate (indent * 2) ' '
 
+colourText :: Int -> String -> String
+colourText i text =
+    "<span class=\"" ++ cssColourClass i ++ "\">" ++ text ++ "</span>"
+
+css :: [String]
+css =
+    ["<style>", "body {background-color: white;}"] ++
+    (defineColourClass <$> [0 .. noCssColours - 1]) ++
+    ["</style>"]
+    where
+    defineColourClass i =
+        '.' : cssColourClass i ++ " {color: " ++ cssColour i ++ ";}"
+
+cssColourClass :: Int -> String
+cssColourClass i = "c" ++ show (rem i noCssColours)
+
+noCssColours :: Int
+noCssColours = 4
+
+cssColour :: Int -> String
+cssColour 0 = "black"
+cssColour 1 = "#e6194B"
+cssColour 2 = "#4363d8"
+cssColour 3 = "#f58231"
 
 reportText :: [Tree Val] -> [String]
 reportText vals =


### PR DESCRIPTION
I really wanted [this feature](https://github.com/ndmitchell/profiterole/issues/5), so I implemented it without waiting for you to respond to the issue. 

The first web page I found that suggests palettes of more than two mutually distinctive accessible colours is [this](https://sashamaps.net/docs/resources/20-colors/). Unfortunately, even the colours that are supposed to be accessible to 99.99% of people turned out to be hard to distinguish/read when you have a thin font on a white background. So based on the description of colour perception issues at the bottom of that page, I picked a subset of 4 legible colours that should hopefully work for 99.99% of people. This is how it looks:

![ColourfulProfiterole](https://github.com/user-attachments/assets/0d88da1a-fe9f-42b9-8383-ed99189eb23f)
